### PR TITLE
Double folder structure when concatenating js

### DIFF
--- a/_gulp/config.js
+++ b/_gulp/config.js
@@ -38,7 +38,7 @@ module.exports = {
             themePath + 'Core/Js/loader.js'
 
         ],
-        concatFilename: themePath + 'theme.concat.js', // result filename
+        concatFilename: 'theme.concat.js', // result filename
         jsDest: themePath + 'Core/Js/'
     },
 


### PR DESCRIPTION
The `src/Frontend/Themes/theme_name` folder is being (newly) generated into the `src/Frontend/Themes/theme_name/Core/Js/` because of the themePath variable preceding the concatenated filename.
